### PR TITLE
add ServerRegistry

### DIFF
--- a/redistest/registry.go
+++ b/redistest/registry.go
@@ -1,0 +1,73 @@
+package redistest
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	redis "github.com/segmentio/redis-go"
+)
+
+// MakeServerRegistry is the type of factory functions that the
+// TestServerRegistry test suite uses to create Clients to run the
+// tests against.
+type MakeServerRegistry func() (redis.ServerRegistry, []redis.ServerEndpoint, func(), error)
+
+// TestServerRegistry is a test suite which verifies the behavior of
+// ServerRegistry implementations.
+func TestServerRegistry(t *testing.T, makeServerRegistry MakeServerRegistry) {
+	tests := []struct {
+		scenario string
+		function func(*testing.T, context.Context, redis.ServerRegistry, []redis.ServerEndpoint)
+	}{
+		{
+			scenario: "calling ListServers with a canceled context should return an error",
+			function: testServerRegistryCancel,
+		},
+		{
+			scenario: "calling ListServers should return the expected list of servers",
+			function: testServerRegistryListServers,
+		},
+	}
+
+	for _, test := range tests {
+		testFunc := test.function
+
+		t.Run(test.scenario, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			registry, endpoints, close, err := makeServerRegistry()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer close()
+			testFunc(t, ctx, registry, endpoints)
+		})
+	}
+}
+
+func testServerRegistryCancel(t *testing.T, ctx context.Context, registry redis.ServerRegistry, endpoints []redis.ServerEndpoint) {
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	if _, err := registry.ListServers(ctx); err == nil {
+		t.Error("expected a non-nil error but got", err)
+	}
+}
+
+func testServerRegistryListServers(t *testing.T, ctx context.Context, registry redis.ServerRegistry, endpoints []redis.ServerEndpoint) {
+	servers, err := registry.ListServers(ctx)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if !reflect.DeepEqual(servers, endpoints) {
+		t.Error("server endpoints don't match:")
+		t.Logf("expected: %#v", endpoints)
+		t.Logf("found:    %#v", servers)
+	}
+}

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,44 @@
+package redis
+
+import (
+	"context"
+	"net"
+)
+
+// The ServerRegistry interface is an abstraction used to expose a (potentially
+// changing) list of backend redis servers.
+type ServerRegistry interface {
+	// ListServers returns a list of redis server endpoints.
+	ListServers(ctx context.Context) ([]ServerEndpoint, error)
+}
+
+// A ServerEndpoint represents a single backend redis server.
+type ServerEndpoint struct {
+	Name string
+	Addr net.Addr
+}
+
+// ListServers satisfies the ServerRegistry interface.
+func (endpoint ServerEndpoint) ListServers(ctx context.Context) ([]ServerEndpoint, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		return []ServerEndpoint{endpoint}, nil
+	}
+}
+
+// A ServerList represents a list of backend redis servers.
+type ServerList []ServerEndpoint
+
+// ListServers satisfies the ServerRegistry interface.
+func (list ServerList) ListServers(ctx context.Context) ([]ServerEndpoint, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+		res := make([]ServerEndpoint, len(list))
+		copy(res, list)
+		return res, nil
+	}
+}

--- a/registry_test.go
+++ b/registry_test.go
@@ -1,0 +1,27 @@
+package redis_test
+
+import (
+	"net"
+	"testing"
+
+	redis "github.com/segmentio/redis-go"
+	"github.com/segmentio/redis-go/redistest"
+)
+
+func TestServerEndpoint(t *testing.T) {
+	redistest.TestServerRegistry(t, func() (redis.ServerRegistry, []redis.ServerEndpoint, func(), error) {
+		endpoint := redis.ServerEndpoint{Name: "A", Addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 4242}}
+		return endpoint, []redis.ServerEndpoint{endpoint}, func() {}, nil
+	})
+}
+
+func TestServerList(t *testing.T) {
+	redistest.TestServerRegistry(t, func() (redis.ServerRegistry, []redis.ServerEndpoint, func(), error) {
+		endpoints := []redis.ServerEndpoint{
+			{Name: "A", Addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 4242}},
+			{Name: "B", Addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 4243}},
+			{Name: "C", Addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 4244}},
+		}
+		return redis.ServerList(endpoints), endpoints, func() {}, nil
+	})
+}


### PR DESCRIPTION
This is an abstraction to inject the list of servers into the reverse proxy, the intent is to have `redis.ServerRegistry` implemented as a static list of servers, or as a dynamic list that would be periodically looked up against a service discovery backend like Consul.