### PR TITLE
Red

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ _testmain.go
 
 # Emacs
 *~
+
+/red

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+COPY red /usr/local/bin/red
+ENTRYPOINT ["red"]

--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ test:
       --volume ${PWD}:/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       --workdir /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       segment/golang:latest
-      go.build='CGO_ENABLED=0 go build -ldflags \"-X main.version=${CIRCLE_TAGS:-$CIRCLE_SHA1}\" ./cmd/red'
+      go.build="CGO_ENABLED=0 go build -ldflags \"-X main.version=${CIRCLE_TAGS:-$CIRCLE_SHA1}\" ./cmd/red"
     - docker build -t segment/red .
 
 deployment:

--- a/circle.yml
+++ b/circle.yml
@@ -23,3 +23,12 @@ test:
       --volume ${PWD}:/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       --workdir /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       segment/golang:latest
+      go.build='CGO_ENABLED=0 go build -ldflags \"-X main.version=${CIRCLE_TAGS:-$CIRCLE_SHA1}\" ./cmd/red'
+
+deployment:
+  release:
+    tag: /.*/
+    commands:
+      - docker tag segment/red segment/red:${CIRCLE_TAG}
+      - docker login -e ${DOCKER_EMAIL} -u ${DOCKER_USER} -p ${DOCKER_PASS}
+      - docker push segment/red

--- a/circle.yml
+++ b/circle.yml
@@ -24,6 +24,7 @@ test:
       --workdir /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       segment/golang:latest
       go.build='CGO_ENABLED=0 go build -ldflags \"-X main.version=${CIRCLE_TAGS:-$CIRCLE_SHA1}\" ./cmd/red'
+    - docker build -t segment/red .
 
 deployment:
   release:

--- a/cmd/red/main.go
+++ b/cmd/red/main.go
@@ -44,6 +44,10 @@ func main() {
 	}
 }
 
+// The signals function configures the program to receive the list of signals
+// given as argument. It returns a channel from which the program can receive
+// notifications that those signals arrived, and a teardown function that
+// removes the signal handlers when it is called.
 func signals(signals ...os.Signal) (<-chan os.Signal, func()) {
 	sigchan := make(chan os.Signal)
 	sigrecv := events.Signal(sigchan)

--- a/cmd/red/main.go
+++ b/cmd/red/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/segmentio/conf"
+	"github.com/segmentio/events"
+	_ "github.com/segmentio/events/ecslogs"
+	_ "github.com/segmentio/events/log"
+	_ "github.com/segmentio/events/sigevents"
+	_ "github.com/segmentio/events/text"
+)
+
+var version = ""
+
+func main() {
+	var err error
+	var ld = conf.Loader{
+		Name: "red",
+		Args: os.Args[1:],
+		Commands: []conf.Command{
+			{"proxy", "Run the RED proxy"},
+			{"help", "Show the RED help"},
+			{"version", "Show the RED version"},
+		},
+	}
+
+	switch cmd, args := conf.LoadWith(nil, ld); cmd {
+	case "proxy":
+		err = proxy(args)
+	case "help":
+		ld.PrintHelp(nil)
+	case "version":
+		fmt.Println(version)
+	default:
+		panic("unreachable")
+	}
+
+	if err != nil {
+		events.Log("%{error}s", err)
+		os.Exit(1)
+	}
+}
+
+func signals(signals ...os.Signal) (<-chan os.Signal, func()) {
+	sigchan := make(chan os.Signal)
+	sigrecv := events.Signal(sigchan)
+	signal.Notify(sigchan, signals...)
+	return sigrecv, func() { signal.Stop(sigchan) }
+}

--- a/cmd/red/proxy.go
+++ b/cmd/red/proxy.go
@@ -2,19 +2,27 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/url"
 	"os"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/segmentio/conf"
+	consul "github.com/segmentio/consul-go"
 	"github.com/segmentio/events"
-	"github.com/segmentio/events/log"
+	eventslog "github.com/segmentio/events/log"
 	redis "github.com/segmentio/redis-go"
 )
 
 type proxyConfig struct {
-	Bind  string `conf:"bind"  help:"Address on which the proxy is listening for incoming connections." validate:"nonzero"`
-	Debug bool   `conf:"debug" help:"Enable debug mode."`
+	Bind     string `conf:"bind"     help:"Address on which the proxy is listening for incoming connections." validate:"nonzero"`
+	Upstream string `conf:"upstream" help:"URL or comma-separated list of upstream servers."                  validate:"nonzero"`
+	Debug    bool   `conf:"debug"    help:"Enable debug mode."`
 }
 
 func proxy(args []string) (err error) {
@@ -33,14 +41,14 @@ func proxy(args []string) (err error) {
 	events.DefaultLogger.EnableDebug = config.Debug
 	events.DefaultLogger.EnableSource = config.Debug
 
-	server := &redis.Server{
-		Addr:         config.Bind,
-		Handler:      &redis.ReverseProxy{},
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 30 * time.Second,
-		IdleTimeout:  90 * time.Second,
-		ErrorLog:     log.NewLogger("", 0, events.DefaultHandler),
-	}
+	defer func() {
+		if err == nil {
+			err = convertPanicToError(recover())
+		}
+	}()
+
+	lstn := makeListener(config.Bind)
+	server := makeProxyServer(config)
 
 	sigchan, sigstop := signals(syscall.SIGINT, syscall.SIGTERM)
 	defer sigstop()
@@ -51,13 +59,162 @@ func proxy(args []string) (err error) {
 		server.Shutdown(context.Background())
 	}()
 
-	if err = server.ListenAndServe(); err == redis.ErrServerClosed {
+	events.Log("listening on '%{address}s' for incoming connections", lstn.Addr())
+
+	if err = server.Serve(lstn); err == redis.ErrServerClosed {
 		err = nil
 	}
 
 	return
 }
 
+func makeListener(addr string) net.Listener {
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		panic(err)
+	}
+	return l
+}
+
+func makeProxyServer(config proxyConfig) *redis.Server {
+	logger := eventslog.NewLogger("", 0, events.DefaultHandler)
+	return &redis.Server{
+		Handler:      makeReverseProxy(config, logger),
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  90 * time.Second,
+		ErrorLog:     logger,
+	}
+}
+
+func makeReverseProxy(config proxyConfig, logger *log.Logger) redis.Handler {
+	return &redis.ReverseProxy{
+		Transport: makeTransport(),
+		Registry:  makeRegistry(config.Upstream),
+		ErrorLog:  logger,
+	}
+}
+
+func makeTransport() redis.RoundTripper {
+	// TODO: add metrics
+	return &redis.Transport{
+		ConnsPerHost: 4,
+		PingTimeout:  10 * time.Second,
+		PingInterval: 15 * time.Second,
+	}
+}
+
+func makeRegistry(upstream string) (registry redis.ServerRegistry) {
+	if strings.Index(upstream, "://") < 0 {
+		registry = makeStaticRegistry(upstream)
+	} else {
+		u, err := url.Parse(upstream)
+		if err != nil {
+			panic(err)
+		}
+
+		switch u.Scheme {
+		case "consul":
+			registry = makeConsulRegistry(u)
+
+		default:
+			panic("unsupported registry: " + u.Scheme)
+		}
+	}
+
+	return
+}
+
+func makeStaticRegistry(upstream string) redis.ServerList {
+	addrs := strings.Split(upstream, ",")
+	servers := make(redis.ServerList, len(addrs))
+
+	for i, addr := range addrs {
+		var name string
+
+		if at := strings.IndexByte(addr, '@'); at < 0 {
+			events.Log("adding '%{redis_server_addr}s' to the list of upstream redis servers", addr)
+		} else {
+			name, addr = addr[:at], addr[at+1:]
+			events.Log("adding '%{redis_server_addr}s' as '%{redis_server_name}s' to the list of upstream redis servers", addr, name)
+		}
+
+		servers[i] = redis.ServerEndpoint{
+			Name: name,
+			Addr: addr,
+		}
+	}
+
+	return servers
+}
+
+func makeConsulRegistry(u *url.URL) *consulRegistry {
+	v := u.Query()
+
+	r := &consulRegistry{
+		service: strings.TrimPrefix(u.Path, "/"),
+		cluster: v.Get("cluster"),
+		client: &consul.Client{
+			Address:    u.Host,
+			UserAgent:  fmt.Sprintf("RED (github.com/segmentio/redis-go, version %s)", version),
+			Datacenter: v.Get("dc"),
+		},
+		resolver: &consul.Resolver{
+			OnlyPassing: true,
+			Cache:       &consul.ResolverCache{},
+			Blacklist:   &consul.ResolverBlacklist{},
+		},
+	}
+
+	if len(r.cluster) != 0 {
+		r.resolver.ServiceTags = []string{"redis-cluster:" + r.cluster}
+	}
+
+	r.resolver.Client = r.client
+
+	events.Log("using '%{redis_service_name}s' services of the '%{redis_cluster_name}s' from the consul registry at '%{consul_addr}s'",
+		r.cluster,
+		r.service,
+		r.client.Address,
+	)
+
+	return r
+}
+
 type consulRegistry struct {
-	agent string
+	service  string
+	cluster  string
+	client   *consul.Client
+	resolver *consul.Resolver
+}
+
+func (r *consulRegistry) LookupServers(ctx context.Context) ([]redis.ServerEndpoint, error) {
+	endpoints, err := r.resolver.LookupService(ctx, r.service)
+	if err != nil {
+		return nil, err
+	}
+
+	servers := make([]redis.ServerEndpoint, len(endpoints))
+
+	for i, e := range endpoints {
+		servers[i] = redis.ServerEndpoint{
+			Name: e.ID,
+			Addr: e.Addr.String(),
+		}
+	}
+
+	return servers, nil
+}
+
+func convertPanicToError(v interface{}) error {
+	switch x := v.(type) {
+	case nil:
+		return nil
+	case error:
+		return x
+	case string:
+		return errors.New(x)
+	default:
+		return fmt.Errorf("%v", x)
+	}
 }

--- a/cmd/red/proxy.go
+++ b/cmd/red/proxy.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/segmentio/conf"
+	"github.com/segmentio/events"
+	"github.com/segmentio/events/log"
+	redis "github.com/segmentio/redis-go"
+)
+
+type proxyConfig struct {
+	Bind  string `conf:"bind"  help:"Address on which the proxy is listening for incoming connections." validate:"nonzero"`
+	Debug bool   `conf:"debug" help:"Enable debug mode."`
+}
+
+func proxy(args []string) (err error) {
+	config := proxyConfig{
+		Bind: ":6479",
+	}
+
+	conf.LoadWith(&config, conf.Loader{
+		Name: "red proxy",
+		Args: args,
+		Sources: []conf.Source{
+			conf.NewEnvSource("RED", os.Environ()...),
+		},
+	})
+
+	events.DefaultLogger.EnableDebug = config.Debug
+	events.DefaultLogger.EnableSource = config.Debug
+
+	server := &redis.Server{
+		Addr:         config.Bind,
+		Handler:      &redis.ReverseProxy{},
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  90 * time.Second,
+		ErrorLog:     log.NewLogger("", 0, events.DefaultHandler),
+	}
+
+	sigchan, sigstop := signals(syscall.SIGINT, syscall.SIGTERM)
+	defer sigstop()
+
+	go func() {
+		<-sigchan
+		sigstop()
+		server.Shutdown(context.Background())
+	}()
+
+	if err = server.ListenAndServe(); err == redis.ErrServerClosed {
+		err = nil
+	}
+
+	return
+}
+
+type consulRegistry struct {
+	agent string
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,18 +14,39 @@ services:
     image: redis
     ports:
       - 6379:6379
+    environment:
+      SERVICE_TAGS: redis-cluster:test
 
   redis-2:
     image: redis
     ports:
       - 6380:6379
+    environment:
+      SERVICE_TAGS: redis-cluster:test
 
   redis-3:
     image: redis
     ports:
       - 6381:6379
+    environment:
+      SERVICE_TAGS: redis-cluster:test
 
   redis-4:
     image: redis
     ports:
       - 6382:6379
+    environment:
+      SERVICE_TAGS: redis-cluster:test
+
+  registrator:
+    image: gliderlabs/registrator
+    command: "-cleanup -ip 127.0.0.1 -resync 1 -retry-attempts 1000 -retry-interval 1000 consul://localhost:8500"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock
+    depends_on:
+      - consul
+      - redis-1
+      - redis-2
+      - redis-3
+      - redis-4
+    network_mode: host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,15 @@
 version: '2'
 
 services:
+  consul:
+    image: "consul"
+    command: "-server -bootstrap-expect 1 -ui"
+    hostname: "localhost"
+    ports:
+      - "8400:8400"
+      - "8500:8500"
+      - "8600:53"
+
   redis-1:
     image: redis
     ports:


### PR DESCRIPTION
The changes in this PR add the basic structure for the `red proxy` program, which support for using a static list of upstream redis servers, or a set of servers discovered using consul.

There's plenty of things to add but this should be a good skeleton to start from.