### PR TITLE
ge/cmd test

### DIFF
--- a/cmd/red/main.go
+++ b/cmd/red/main.go
@@ -22,6 +22,7 @@ func main() {
 		Args: os.Args[1:],
 		Commands: []conf.Command{
 			{"proxy", "Run the RED proxy"},
+			{"test", "Run the RED proxy test"},
 			{"help", "Show the RED help"},
 			{"version", "Show the RED version"},
 		},
@@ -30,6 +31,8 @@ func main() {
 	switch cmd, args := conf.LoadWith(nil, ld); cmd {
 	case "proxy":
 		err = proxy(args)
+	case "test":
+		err = test(args)
 	case "help":
 		ld.PrintHelp(nil)
 	case "version":

--- a/cmd/red/test.go
+++ b/cmd/red/test.go
@@ -20,7 +20,7 @@ type testConfig struct {
 	Dogstatsd string `conf:"dogstatsd" help:"Address of the dogstatsd agent to send metrics to, in ip:port format."                validate:"nonzero"`
 	Batch     int    `conf:"batch" help:"Test batch size: number of keys to read and write in each test run."`
 	Runs      int    `conf:"runs" help:"Number of times to cycle the test. Specify zero to run indefinitely."`
-	Sleep     int    `conf:"sleep" help:"Maximum interval, in seconds, that each operation is delayed in order to throttle traffic to the proxy."`
+	Sleep     int    `conf:"sleep" help:"Maximum interval, in seconds, that each operation is uniformly randomly delayed in order to throttle traffic to the proxy."`
 }
 
 func test(args []string) (err error) {

--- a/cmd/red/test.go
+++ b/cmd/red/test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"github.com/segmentio/conf"
+	"github.com/segmentio/events"
+	eventslog "github.com/segmentio/events/log"
+	redis "github.com/segmentio/redis-go"
+	"github.com/segmentio/redis-go/redistest"
+	"github.com/segmentio/stats"
+	"github.com/segmentio/stats/datadog"
+	"github.com/segmentio/stats/redisstats"
+	"math/rand"
+	"os"
+	"time"
+)
+
+type testConfig struct {
+	Proxy     string `conf:"proxy" help:"Address on which the RED proxy under test is listening for incoming connections, in ip:port format." validate:"nonzero"`
+	Dogstatsd string `conf:"dogstatsd" help:"Address of the dogstatsd agent to send metrics to, in ip:port format."                validate:"nonzero"`
+	Batch     int    `conf:"batch" help:"Test batch size: number of keys to read and write in each test run."`
+	Runs      int    `conf:"runs" help:"Number of times to cycle the test. Specify zero to run indefinitely."`
+	Sleep     int    `conf:"sleep" help:"Maximum interval, in seconds, that each operation is delayed in order to throttle traffic to the proxy."`
+}
+
+func test(args []string) (err error) {
+	logger := eventslog.NewLogger("", 0, events.DefaultHandler)
+	engine := stats.DefaultEngine
+
+	config := testConfig{
+		Batch: 160,
+		Sleep: 5,
+	}
+
+	conf.LoadWith(&config, conf.Loader{
+		Name: "red proxy",
+		Args: args,
+		Sources: []conf.Source{
+			conf.NewEnvSource("RED", os.Environ()...),
+		},
+	})
+
+	if len(config.Dogstatsd) != 0 {
+		stats.Register(datadog.NewClient(config.Dogstatsd))
+	}
+	defer stats.Flush()
+
+	logger.Printf("Starting test.\n\tProxy: %s\n\tDogstatsd: %s\n\tBatch: %d\n\tRuns: %d\n\tSleep: %d\n",
+		config.Proxy, config.Dogstatsd, config.Batch, config.Runs, config.Sleep)
+	for i := 0; config.Runs == 0 || i < config.Runs; i++ {
+		logger.Printf("Starting run #%d.", i)
+		transport := redisstats.NewTransport(&redis.Transport{})
+		client := &redis.Client{Addr: config.Proxy, Transport: transport}
+		logger.Printf("Instantiated client.")
+
+		keyNs := fmt.Sprintf("redis-go.red_test.%d.%06d", time.Now().UnixNano(), rand.Int31n(1000000))
+		logger.Printf("keyNs: '%s'", keyNs)
+
+		logger.Printf("config.Batch: %d", config.Batch)
+
+		keyTempl := fmt.Sprintf("%s.%%d", keyNs)
+		ws, wf, werr := redistest.WriteTestPattern(client, config.Batch, keyTempl, time.Duration(config.Sleep)*time.Second, 30*time.Second)
+		if werr != nil {
+			logger.Printf("Errors during write: %s", werr)
+		}
+		logger.Printf("ws: %d, wf: %d", ws, wf)
+		engine.Add("test.writes", float64(ws), stats.Tag{Name: "result", Value: "success"})
+		engine.Add("test.writes", float64(wf), stats.Tag{Name: "result", Value: "failure"})
+		rh, rm, re, rerr := redistest.ReadTestPattern(client, config.Batch, keyTempl, time.Duration(config.Sleep)*time.Second, 30*time.Second)
+		if rerr != nil {
+			logger.Printf("Errors during read: %s", rerr)
+		}
+		logger.Printf("rh: %d, rm: %d, re: %d", rh, rm, re)
+		engine.Add("test.reads", float64(rh), stats.Tag{Name: "result", Value: "hit"})
+		engine.Add("test.reads", float64(rm), stats.Tag{Name: "result", Value: "miss"})
+		engine.Add("test.reads", float64(re), stats.Tag{Name: "result", Value: "error"})
+		logger.Printf("Completed run #%d.", i)
+	}
+	logger.Printf("Completed all runs.")
+	return nil
+}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1,15 +1,12 @@
 package redis_test
 
 import (
-	"context"
-	"fmt"
 	redis "github.com/segmentio/redis-go"
 	"github.com/segmentio/redis-go/redistest"
 	"github.com/stretchr/testify/assert"
 	"log"
 	"net/url"
 	"os"
-	"sync"
 	"testing"
 	"time"
 )
@@ -54,50 +51,55 @@ func TestReverseProxyHash(t *testing.T) {
 	n := 160
 	keyTempl := "redis-go.test.rphash.%d"
 
-	numSuccess, numFailure, errs := writeBlock(client, n, keyTempl)
+	sleep := 5 * time.Second
+	timeout := 30 * time.Second
+
+	numSuccess, numFailure, err := redistest.WriteTestPattern(client, n, keyTempl, sleep, timeout)
 	assert.Equal(t, n, numSuccess, "All writes succeeded")
 	assert.Equal(t, 0, numFailure, "No writes failed")
-	if errs != nil {
-		t.Error(errs)
+	if err != nil {
+		t.Error(err)
 		return
 	}
 
-	timeout := 30 * time.Second
-
 	// full backend - read n back
-	numHits, numMisses, err := measHitMiss(client, n, keyTempl, timeout)
-	t.Logf("full backend n read: numHits = %d, numMisses = %d, err = %v", numHits, numMisses, err)
+	numHits, numMisses, numErrs, err := redistest.ReadTestPattern(client, n, keyTempl, sleep, timeout)
+	t.Logf("full backend n read: numHits = %d, numMisses = %d, numErrs = %d, err = %v", numHits, numMisses, numErrs, err)
 	assert.Nil(t, err, "Full backend - no errors")
 	assert.Equal(t, n, numHits, "Full backend - all hit")
 	assert.Equal(t, 0, numMisses, "Full backend - none missed")
+	assert.Equal(t, 0, numErrs, "Full backend - no errors")
 
 	// full backend - read n+1 back
-	numHits, numMisses, err = measHitMiss(client, n+1, keyTempl, timeout)
-	t.Logf("full backend n+1 read: numHits = %d, numMisses = %d, err = %v", numHits, numMisses, err)
+	numHits, numMisses, numErrs, err = redistest.ReadTestPattern(client, n+1, keyTempl, sleep, timeout)
+	t.Logf("full backend n+1 read: numHits = %d, numMisses = %d, numErrs = %d, err = %v", numHits, numMisses, numErrs, err)
 	assert.Nil(t, err, "Extra read - no errors")
 	assert.Equal(t, n, numHits, "Extra read - all hit")
 	assert.Equal(t, 1, numMisses, "Extra read - one (additional) missed")
+	assert.Equal(t, 0, numErrs, "Extra read - no errors")
 
 	// malfunctioning backend - read fails
 	proxy.Registry = broken
-	numHits, numMisses, err = measHitMiss(client, n+1, keyTempl, 2*time.Second)
-	t.Logf("broken backend n read: numHits = %d, numMisses = %d, err = %v", numHits, numMisses, err)
+	numHits, numMisses, numErrs, err = redistest.ReadTestPattern(client, 1, keyTempl, sleep, 2*time.Second)
+	t.Logf("broken backend n read: numHits = %d, numMisses = %d, numErrs = %d, err = %v", numHits, numMisses, numErrs, err)
 	assert.NotNil(t, err, "Broken backend - errors")
 	assert.Equal(t, 0, numHits, "Broken backend - none hit")
 	assert.Equal(t, 0, numMisses, "Broken backend - none missed")
+	assert.Equal(t, 1, numErrs, "Broken backend - all errors")
 
 	// single backend dropped (all combinations) - read n back
 	accHits, accMisses := 0, 0
 	for i := 0; i < len(onedowns); i++ {
 		proxy.Registry = onedowns[i]
-		numHits, numMisses, err = measHitMiss(client, n, keyTempl, timeout)
-		t.Logf("single backend dropped (%d): numHits = %d, numMisses = %d, %d%% miss rate, err = %v", i, numHits, numMisses, 100*numMisses/n, err)
+		numHits, numMisses, numErrs, err := redistest.ReadTestPattern(client, n, keyTempl, sleep, timeout)
+		t.Logf("single backend dropped (%d): numHits = %d, numMisses = %d, numErrs = %d, %d%% miss rate, err = %v", i, numHits, numMisses, numErrs, 100*numMisses/n, err)
 		assert.Nil(t, err, "One down - no errors")
 		assert.True(t, numHits < n, "One down - not all hit")
 		assert.True(t, numHits > 0, "One down - some hit")
 		assert.True(t, numMisses < n, "One down - not all missed")
 		assert.True(t, numMisses > 0, "One down - some missed")
 		assert.Equal(t, n, numHits+numMisses, "One down - hits and misses adds up")
+		assert.Equal(t, 0, numErrs, "One down - no errors")
 		accHits += numHits
 		accMisses += numMisses
 	}
@@ -124,88 +126,6 @@ func makeServerList() (full redis.ServerList, broken redis.ServerList, onedowns 
 			}
 		}
 		onedowns = append(onedowns, notith)
-	}
-	return
-}
-
-type MultiError []error
-
-func (err MultiError) Error() string {
-	if len(err) > 0 {
-		return fmt.Sprintf("%d errors. First one: '%s'.", len(err), err[0])
-	} else {
-		return fmt.Sprintf("No errors (weird).")
-	}
-}
-
-func writeBlock(client *redis.Client, n int, keyTempl string) (numSuccess int, numFailure int, err MultiError) {
-	writeErrs := make(chan error, n)
-	waiter := &sync.WaitGroup{}
-	for i := 0; i < n; i++ {
-		key := fmt.Sprintf(keyTempl, i)
-		val := "1"
-		waiter.Add(1)
-		go func(key, val string) {
-			defer waiter.Done()
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			if err := client.Exec(ctx, "SET", key, val); err != nil {
-				writeErrs <- err
-			}
-		}(key, val)
-	}
-	waiter.Wait()
-	close(writeErrs)
-	numFailure = len(writeErrs)
-	numSuccess = n - numFailure
-	if len(writeErrs) > 0 {
-		err = make(MultiError, 0)
-		for writeErr := range writeErrs {
-			err = append(err, writeErr)
-		}
-	}
-	return
-}
-
-func measHitMiss(client *redis.Client, n int, keyTempl string, timeout time.Duration) (numHits, numMisses int, err error) {
-	type tresult struct {
-		hit bool
-		err error
-	}
-	results := make(chan tresult, n)
-	waiter := &sync.WaitGroup{}
-	for i := 0; i < cap(results); i++ {
-		key := fmt.Sprintf(keyTempl, i)
-		waiter.Add(1)
-		go func(key string, rq chan<- tresult) {
-			defer waiter.Done()
-			ctx, cancel := context.WithTimeout(context.Background(), timeout)
-			defer cancel()
-			args := client.Query(ctx, "GET", key)
-			if args.Len() != 1 {
-				rq <- tresult{err: fmt.Errorf("Unexpected response: 1 arg expected; contains %d. ", args.Len())}
-				return
-			}
-			var v string
-			args.Next(&v)
-			if err := args.Close(); err != nil {
-				rq <- tresult{err: err}
-			} else {
-				rq <- tresult{hit: v == "1"}
-			}
-		}(key, results)
-	}
-	waiter.Wait()
-	close(results)
-	for result := range results {
-		if result.err != nil {
-			return 0, 0, result.err
-		}
-		if result.hit {
-			numHits++
-		} else {
-			numMisses++
-		}
 	}
 	return
 }

--- a/redistest/client.go
+++ b/redistest/client.go
@@ -3,6 +3,7 @@ package redistest
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"reflect"
 	"sync"
 	"testing"
@@ -155,4 +156,98 @@ func testClientSubscribe(t *testing.T, ctx context.Context, client Client, names
 	}
 
 	wg.Wait()
+}
+
+type multiError []error
+
+func (err multiError) Error() string {
+	if len(err) > 0 {
+		return fmt.Sprintf("%d errors. First one: '%s'.", len(err), err[0])
+	} else {
+		return fmt.Sprintf("No errors.")
+	}
+}
+
+// WriteTestPattern writes a test pattern to a Redis client. The objective is to read the test pattern back
+// at a later stage using ReadTestPattern.
+func WriteTestPattern(client *redis.Client, n int, keyTempl string, sleep time.Duration, timeout time.Duration) (numSuccess int, numFailure int, err error) {
+	writeErrs := make(chan error, n)
+	waiter := &sync.WaitGroup{}
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf(keyTempl, i)
+		val := "1"
+		waiter.Add(1)
+		go func(key, val string) {
+			defer waiter.Done()
+			time.Sleep(time.Duration(rand.Intn(int(sleep.Seconds()))) * time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			if err := client.Exec(ctx, "SET", key, val); err != nil {
+				writeErrs <- err
+			}
+		}(key, val)
+	}
+	waiter.Wait()
+	close(writeErrs)
+	numFailure = len(writeErrs)
+	numSuccess = n - numFailure
+	if len(writeErrs) > 0 {
+		var merr multiError
+		for writeErr := range writeErrs {
+			merr = append(merr, writeErr)
+		}
+		return numSuccess, numFailure, merr
+	}
+	return numSuccess, numFailure, nil
+}
+
+// ReadTestPattern reads a test pattern (previously writen using WriteTestPattern) from a Redis client and returns hit statistics.
+func ReadTestPattern(client *redis.Client, n int, keyTempl string, sleep time.Duration, timeout time.Duration) (numHits int, numMisses int, numErrors int, err error) {
+	type tresult struct {
+		hit bool
+		err error
+	}
+	results := make(chan tresult, n)
+	waiter := &sync.WaitGroup{}
+	for i := 0; i < cap(results); i++ {
+		key := fmt.Sprintf(keyTempl, i)
+		waiter.Add(1)
+		go func(key string, rq chan<- tresult) {
+			defer waiter.Done()
+			time.Sleep(time.Duration(rand.Intn(int(sleep.Seconds()))) * time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			args := client.Query(ctx, "GET", key)
+			if args.Len() != 1 {
+				rq <- tresult{err: fmt.Errorf("Unexpected response: 1 arg expected; contains %d. ", args.Len())}
+				return
+			}
+			var v string
+			args.Next(&v)
+			if err := args.Close(); err != nil {
+				rq <- tresult{err: err}
+			} else {
+				rq <- tresult{hit: v == "1"}
+			}
+		}(key, results)
+	}
+	waiter.Wait()
+	close(results)
+	var merr multiError
+	for result := range results {
+		if result.err != nil {
+			numErrors++
+			merr = append(merr, result.err)
+		} else {
+			if result.hit {
+				numHits++
+			} else {
+				numMisses++
+			}
+		}
+	}
+	if merr != nil {
+		return numHits, numMisses, numErrors, merr
+	}
+	return numHits, numMisses, numErrors, nil
 }


### PR DESCRIPTION
Add a `test` sub-command to the `red` command which runs a test and emits test metrics. Did some ad-hoc tests on k8s and it seems happy.